### PR TITLE
fix: a workaround prism did since the master key should not be handled

### DIFF
--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialRequest.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialRequest.swift
@@ -118,7 +118,10 @@ extension PolluxImpl {
                 return false
             }),
             case let CredentialOperationsOptions.exportableKeys(exportableKeys) = exportableKeyOption,
-            let exportableFirstKey = exportableKeys.filter({ $0.jwk.crv?.lowercased() == "secp256k1" }).first
+            let exportableFirstKey = exportableKeys.filter({
+                $0.jwk.crv?.lowercased() == "secp256k1"
+                && !($0.jwk.kid?.contains("#master") ?? true) // TODO: This is a hardcoded fix, since prism DID doesnt not recognize master key
+            }).first
         else {
             throw PolluxError.requiresExportableKeyForOperation(operation: "Create Credential Request")
         }


### PR DESCRIPTION
### Description: 
This is a workaround since prism did master did does not show in the DIDDocument.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
