### PR TITLE
fix: anoncreds missing thid

### DIFF
--- a/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
@@ -152,7 +152,8 @@ public extension DIDCommAgent {
             options: [
                 .linkSecret(id: "", secret: linkSecretString),
                 .credentialDefinitionDownloader(downloader: downloader),
-                .schemaDownloader(downloader: downloader)
+                .schemaDownloader(downloader: downloader),
+                message.thid.map { .thid($0) } ?? .thid(message.id)
             ]
         )
 
@@ -222,7 +223,8 @@ public extension DIDCommAgent {
                 .subjectDID(did),
                 .linkSecret(id: did.string, secret: linkSecretString),
                 .credentialDefinitionDownloader(downloader: downloader),
-                .schemaDownloader(downloader: downloader)
+                .schemaDownloader(downloader: downloader),
+                offer.thid.map { .thid($0) } ?? .thid(offer.id)
             ]
         )
 


### PR DESCRIPTION
### Description: 
Anoncreds had a missing parameter

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
