### PR TITLE
feat: add sdjwt as credential type

### DIFF
--- a/EdgeAgentSDK/Domain/Sources/Models/Credentials/Credential.swift
+++ b/EdgeAgentSDK/Domain/Sources/Models/Credentials/Credential.swift
@@ -7,6 +7,9 @@ public enum CredentialType {
 
     /// Represents a credential in AnonCred (Anonymous Credentials) format.
     case anoncred
+
+    /// Represents a credential in SDJWT (Selective Disclosure JSON Web Token) format.
+    case sdjwt
 }
 
 /// `Claim` represents a claim in a credential. Claims are the attributes associated with the subject of a credential.

--- a/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
@@ -30,7 +30,7 @@ public extension DIDCommAgent {
         )
         let attachment: AttachmentDescriptor
         switch type {
-        case .jwt:
+        case .jwt, .sdjwt:
             let data = try AttachmentBase64(base64: rqstStr.tryToData().base64URLEncoded())
             attachment = AttachmentDescriptor(
                 mediaType: "application/json",

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+Presentation.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+Presentation.swift
@@ -39,7 +39,7 @@ extension PolluxImpl {
                     )
                 }
             let presentationDefinition = PresentationDefinition(
-                format: .init(jwt: .init(alg: [.ES256K]), sdJwt: .init(alg: [.ES256K])),
+                format: .init(jwt: .init(alg: [.ES256K])),
                 inputDescriptors: descriptors
             )
 
@@ -85,6 +85,44 @@ extension PolluxImpl {
             )
 
             return try JSONEncoder.didComm().encode(anoncredsPresentation)
+
+        case .sdjwt:
+            let descriptors = claimFilters
+                .map {
+                    InputDescriptor(
+                        name: $0.name,
+                        purpose: $0.purpose,
+                        group: nil,
+                        constraints: .init(
+                            fields: [
+                                .init(
+                                    optional: !$0.required,
+                                    path: $0.paths,
+                                    purpose: $0.purpose,
+                                    intentToRetain: nil,
+                                    name: $0.name,
+                                    filter: .init(
+                                        type: $0.type,
+                                        format: $0.format,
+                                        const: $0.const,
+                                        pattern: $0.pattern
+                                    ),
+                                    predicate: nil
+                                )
+                            ]
+                        )
+                    )
+                }
+            let presentationDefinition = PresentationDefinition(
+                format: .init(sdJwt: .init(alg: [.ES256K])),
+                inputDescriptors: descriptors
+            )
+
+            let container = PresentationExchangeRequest(
+                options: .init(domain: UUID().uuidString, challenge: UUID().uuidString),
+                presentationDefinition: presentationDefinition
+            )
+            return try JSONEncoder.didComm().encode(container)
         }
     }
 }


### PR DESCRIPTION
### Description: 
Now sdjwt will have its own format as credential type

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
