### PR TITLE
fix: presentation now selects the proper key

### DIFF
--- a/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+Proof.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+Proof.swift
@@ -53,24 +53,21 @@ public extension EdgeAgent {
 
             let subjectDID = try DID(string: subjectDIDString)
 
-            let privateKeys = try await pluto.getDIDPrivateKeys(did: subjectDID).first().await()
-
             guard
-                let storedPrivateKey = privateKeys?.first
-            else { throw EdgeAgentError.cannotFindDIDKeyPairIndex }
+                let storedPrivateKeys = try await pluto.getDIDPrivateKeys(did: subjectDID).first().await()
+            else {
+                throw EdgeAgentError.cannotFindDIDKeyPairIndex
+            }
 
-            let privateKey = try await apollo.restorePrivateKey(storedPrivateKey)
-
-            guard
-                let exporting = privateKey.exporting
-            else { throw EdgeAgentError.cannotFindDIDKeyPairIndex }
+            let privateKeys = try await storedPrivateKeys.asyncMap { try await apollo.restorePrivateKey($0) }
+            let exporting = privateKeys.compactMap(\.exporting)
 
             format = requestType == "prism/jwt" ? "prism/jwt" : "dif/presentation-exchange/submission@v1.0"
 
             presentationString = try proofableCredential.presentation(
                 request: request.makeMessage(),
                 options: [
-                    .exportableKey(exporting),
+                    .exportableKeys(exporting),
                     .subjectDID(subjectDID),
                     .disclosingClaims(claims: credential.claims.map(\.key))
                 ]

--- a/EdgeAgentSDK/EdgeAgent/Tests/PresentationExchangeTests.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/PresentationExchangeTests.swift
@@ -38,7 +38,7 @@ final class PresentationExchangeFlowTests: XCTestCase {
         let credential = try JWTCredential(data: jwt.tryToData())
 
         logger.info("Creating presentation request")
-        let message = try await edgeAgent.initiatePresentationRequest(
+        let message = try edgeAgent.initiatePresentationRequest(
             type: .jwt,
             fromDID: DID(method: "test", methodId: "alice"),
             toDID: DID(method: "test", methodId: "bob"),
@@ -108,7 +108,7 @@ final class PresentationExchangeFlowTests: XCTestCase {
         let credential = try SDJWTCredential(sdjwtString: sdjwt)
 
         logger.info("Creating presentation request")
-        let message = try await edgeAgent.initiatePresentationRequest(
+        let message = try edgeAgent.initiatePresentationRequest(
             type: .jwt,
             fromDID: DID(method: "test", methodId: "alice"),
             toDID: DID(method: "test", methodId: "bob"),


### PR DESCRIPTION
### Description: 
There was an issue because master key should not be available with prism did document. This is a fix for the moment further refactoring is needed.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
