### PR TITLE
fix: presentation definition broken

### DIFF
--- a/EdgeAgentSDK/EdgeAgent/Tests/PresentationExchangeTests.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/PresentationExchangeTests.swift
@@ -109,7 +109,7 @@ final class PresentationExchangeFlowTests: XCTestCase {
 
         logger.info("Creating presentation request")
         let message = try edgeAgent.initiatePresentationRequest(
-            type: .jwt,
+            type: .sdjwt,
             fromDID: DID(method: "test", methodId: "alice"),
             toDID: DID(method: "test", methodId: "bob"),
             claimFilters: [
@@ -152,7 +152,8 @@ final class PresentationExchangeFlowTests: XCTestCase {
         )
 
         guard
-            let key = try await edgeAgent.pluto.getDIDPrivateKeys(did: issuerDID).first().await()?.first,
+            let key = try await edgeAgent.pluto.getDIDPrivateKeys(did: issuerDID).first().await()?.first(where: { $0.identifier.contains("authentication0")
+            }),
             let jwkD = try await edgeAgent.apollo.restorePrivateKey(key).exporting?.jwk
         else {
             XCTFail()
@@ -167,7 +168,8 @@ final class PresentationExchangeFlowTests: XCTestCase {
 
     private func makeCredentialSDJWT(issuerDID: DID, subjectDID: DID) async throws -> String {
         guard
-            let key = try await edgeAgent.pluto.getDIDPrivateKeys(did: issuerDID).first().await()?.first,
+            let key = try await edgeAgent.pluto.getDIDPrivateKeys(did: issuerDID).first().await()?.first(where: { $0.identifier.contains("authentication0")
+            }),
             let jwkD = try await edgeAgent.apollo.restorePrivateKey(key).exporting?.jwk
         else {
             XCTFail()

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+Presentation.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+Presentation.swift
@@ -114,7 +114,7 @@ extension PolluxImpl {
                     )
                 }
             let presentationDefinition = PresentationDefinition(
-                format: .init(sdJwt: .init(alg: [.ES256K])),
+                format: .init(sdJwt: .init(alg: [.EdDSA, .ES256K])),
                 inputDescriptors: descriptors
             )
 

--- a/build_test.sh
+++ b/build_test.sh
@@ -20,6 +20,8 @@ echo "Cleaning lcov partials directory"
 rm -rf "$LCOV_DIR"
 mkdir "$LCOV_DIR"
 
+set -euo pipefail
+
 # Run build and test
 echo "Running build and test"
 xcodebuild -scheme "EdgeAgentSDK-Package" \


### PR DESCRIPTION
### Description: 
There was as well a fix for the current CI that was not failing on test fails

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
