### PR TITLE
fix(e2e): align E2E package platform floor with SDK root

### DIFF
--- a/E2E/Package.swift
+++ b/E2E/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "e2e",
-    platforms: [.iOS(.v15), .macOS(.v12)],
+    platforms: [.iOS(.v15), .macOS(.v14)],
     products: [
         .library(
             name: "TestFramework",


### PR DESCRIPTION
## Problem

The E2E `Package.swift` declares `swift-tools-version: 5.7` and a macOS `v12` platform, but the SDK root `Package.swift` requires macOS `v14` (raised from `v13` → `v14` in `8.0.0`, commit `6218165`). This mismatch breaks `xcodebuild build-for-testing` for the `e2e` target against the 8.x SDK:

```
error: The package product 'EdgeAgent' requires minimum platform version 14.0 for the macOS platform,
       but this target supports 13.0 (in target 'e2e-tests' from project 'e2e')
```

Raising only the platform to `.v14` is insufficient: with `swift-tools-version: 5.7`, `.macOS(.v14)` is itself unavailable (`'v14' is unavailable`) because the v14 platform requires `swift-tools` 5.9+.

## Fix

- Bump `swift-tools-version` `5.7 → 5.9` (matches the root `Package.swift`; required so `.macOS(.v14)` is available).
- Raise the E2E macOS platform `.v12 → .v14` to match the root `Package.swift` platform floor.

## Verification

Confirmed end-to-end via the [integration](https://github.com/hyperledger-identus/integration) suite (`just run-sdk-swift-e2e`, two consecutive runs) against a locally-hosted Identus stack (cloud-agent `2.2.0`, mediator `1.2.0`):

```
Test Suite 'All tests' passed
Executed 21 tests, with 2 tests skipped and 0 failures (0 unexpected)
```

Previously the 8.x SDK could not build its own E2E tests at all; with this change the full suite (JWT/SD-JWT/AnonCreds issuance + verification, proofs, revocation) passes.

Signed-off-by: Pat Losoponkul <patextreme@hotmail.com>