### PR TITLE
fix(e2e): adapt E2E tests to EdgeAgent seed callback API

### DIFF
--- a/E2E/Tests/Source/Abilities/DidcommAgentAbility.swift
+++ b/E2E/Tests/Source/Abilities/DidcommAgentAbility.swift
@@ -92,6 +92,7 @@ class DidcommAgentAbility: Ability {
             .core: .error
         ])
         
+        let seed = seed
         let edgeAgent = EdgeAgent(
             apollo: apollo,
             castor: castor,

--- a/E2E/Tests/Source/Abilities/DidcommAgentAbility.swift
+++ b/E2E/Tests/Source/Abilities/DidcommAgentAbility.swift
@@ -97,7 +97,7 @@ class DidcommAgentAbility: Ability {
             castor: castor,
             pluto: pluto,
             pollux: pollux,
-            seed: seed
+            seed: { seed }
         )
         
         didcommAgent = DIDCommAgent(

--- a/E2E/Tests/Source/Workflows/EdgeAgentWorkflow.swift
+++ b/E2E/Tests/Source/Workflows/EdgeAgentWorkflow.swift
@@ -134,7 +134,7 @@ class EdgeAgentWorkflow {
                 )
                 break
             case "prism/jwt":
-                let seed = sdk.didcommAgent.edgeAgent.seed
+                let seed = try await sdk.didcommAgent.edgeAgent.seed()
                 let privateKey = try sdk.didcommAgent.apollo.createPrivateKey(parameters: [
                     KeyProperties.type.rawValue: "EC",
                     KeyProperties.curve.rawValue: KnownKeyCurves.secp256k1.rawValue,
@@ -249,7 +249,7 @@ class EdgeAgentWorkflow {
             description: "creates a backup"
         ) { sdk in
             let backup = try await sdk.didcommAgent.edgeAgent.backupWallet()
-            let seed = sdk.didcommAgent.edgeAgent.seed
+            let seed = try await sdk.didcommAgent.edgeAgent.seed()
             try await edgeAgent.remember(key: "backup", value: backup)
             try await edgeAgent.remember(key: "seed", value: seed)
         }


### PR DESCRIPTION
## Problem

`feat(agent): init now receives a seed callback` (#233, commit `a4cd164`, shipped in `8.1.0`) changed `EdgeAgent.seed` from a `Seed` value to an async closure, and updated the `seed:` initializer parameter from `Seed?` to `(() async throws -> Seed)?`:

```swift
public let seed: () async throws -> Seed          // was: public let seed: Seed
public init(..., seed: (() async throws -> Seed)? = nil)  // was: seed: Seed? = nil
```

The SDK **unit tests** (`BackupWalletTests`, `PrismOnboardingInvitationTests`) were updated in that same commit, but the **E2E tests** were not. As a result the `e2e` test target no longer compiles against the 8.x SDK:

```
DidcommAgentAbility.swift:100:19: error: cannot convert value of type 'Seed'
  to expected argument type '(() async throws -> Seed)?'
```

`xcodebuild build-for-testing` fails (`** TEST BUILD FAILED **`), so no E2E tests can run. This was surfaced by an integration run against the locally-hosted Identus stack ([integration run #27693263471](https://github.com/hyperledger-identus/integration/actions/runs/27693263471)).

## Solution

Update the three E2E sites that consume the seed to mirror the pattern already used by the unit tests (e.g. `BackupWalletTests`):

- `DidcommAgentAbility.swift` — pass a `() async throws -> Seed` closure to `EdgeAgent`'s initializer. A local `let seed = seed` value copy is bound before the init so the escaping closure captures the value (not `self`), which both satisfies Swift's explicit-capture requirement and avoids a retain cycle.
- `EdgeAgentWorkflow.swift` — call `try await edgeAgent.seed()` instead of reading `edgeAgent.seed` directly (two sites: the `prism/jwt` credential-offer path and the `createBackup` path).

```diff
-            seed: seed
+            let seed = seed
+            ...
+            seed: { seed }
```
```diff
-            let seed = sdk.didcommAgent.edgeAgent.seed
+            let seed = try await sdk.didcommAgent.edgeAgent.seed()
```

No SDK public API or behavior is changed — this is a test-only fix.

## Verification

Pointed the integration local-tunnel E2E suite at this branch and ran it to green. Verified suite: `** TEST EXECUTE SUCCEEDED **` — 23 tests executed, 0 failures (2 skipped).

- CI run: https://github.com/hyperledger-identus/integration/actions/runs/27696400618 (sdk-swift ref `8.1.1-rc.2` on this branch)
- Stack under test: cloud-agent `2.2.0`, mediator `1.2.1`, neoprism `0.14.1`

### Alternatives Considered

None. This follows the exact pattern the SDK's own unit tests adopted for the same breaking change, so the E2E tests stay consistent with the rest of the suite.

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)